### PR TITLE
GH-27 Check for common erase keys (BS and DEL) plus erasechar() to

### DIFF
--- a/options.c
+++ b/options.c
@@ -272,7 +272,8 @@ get_str(void *vopt, WINDOW *win)
     {
 	if (c == -1)
 	    continue;
-	else if (c == erasechar())	/* process erase character */
+	/* Check erase and avoid stty erase vs terminal emulator key conflicts. */
+	else if (c == '\b' || c == 0x7F || c == erasechar())
 	{
 	    if (sp > buf)
 	    {


### PR DESCRIPTION
avoid the user having to fight with their terminal emulator (Cygwin Mintty) options and stty(1) erase setting. Just make it work sanely.