### PR TITLE
GH-30 Test if stdscr exists before calling isendwin(), otherwise a

### DIFF
--- a/mdport.c
+++ b/mdport.c
@@ -116,7 +116,7 @@ endwin_and_ncurses_cleanup(void)
     /*
      * ncurses cleanup unless endwin() was already called
      */
-    if (!isendwin()) {
+    if (stdscr != NULL && !isendwin()) {
 
 	/*
 	 * move to corner of window


### PR DESCRIPTION
seg.fault can ensue wih some Curses implentations.