### PR TITLE
NetBSD: Fix build when ncurses package is installed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,12 @@ AT= @
 #
 target=$(shell uname -s 2>/dev/null)
 ifeq ($(target),NetBSD)
-LIBS= -lcurses
+# Ncurses package installed or use old curses.h?
+LIBS!=if test -f /usr/pkg/include/ncurses/ncurses.h; then echo '-lncurses'; else echo '-lcurses'; fi
+	ifeq ($(LIBS),-lncurses)
+		CPPFLAGS=-I/usr/pkg/include -I/usr/pkg/include/ncurses
+		LDFLAGS=-L/usr/pkg/lib
+	endif
 else
 LIBS= -lncurses
 endif
@@ -470,11 +475,11 @@ modern_curses.h: ${MAKE_FILE}
 	${Q} echo '' >> $@
 	${Q} echo '' >> $@
 	${Q} echo '/* do have modern new curses ? */' >> $@
-	-${Q} if echo '#include <ncurses.h>' | ${CC} -E - ${S}; then \
+	-${Q} if echo '#include <ncurses.h>' | ${CC} -E ${CPPFLAGS} - ${S}; then \
 	    echo '#include <ncurses.h> /* yes, using new curses */' >> $@; \
 	    echo >> $@; \
 	    echo '#define MODERN_CURSES NEW_CURSES' >> $@; \
-	elif echo '#include <curses.h>' | ${CC} -E - ${S}; then \
+	elif echo '#include <curses.h>' | ${CC} -E ${CPPFLAGS} - ${S}; then \
 	    echo '#include <curses.h> /* no, you have old curses, or what NetBSD calls curses */' >> $@; \
 	    echo >> $@; \
 	    echo '#define MODERN_CURSES OLD_CURSES' >> $@; \


### PR DESCRIPTION
Rogue does not detect Ncurses when it is installed as binary package and is located in another tree, such as `/usr/pkg`.  FreeBSD is similarly, but uses `/usr/local` (which IMO is more correct, oh well).  Either way, Rogue Makefile when testing for headers fails to include `CPPFLAGS` macros with `-E`, so anyone overriding macro (`CPPFLAGS`, `LDFLAGS`) from the `make` command line still would not detect NCurses or link correctly.  

This change should address the header detection and clean NetBSD build with NCurses.  FreeBSD is an exercise for the FreeBSD reader.
